### PR TITLE
docs: Move compatibility note to the shared docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -23,16 +23,7 @@ use them, see the documentation from the parent page:
 
 ## Compatibility
 
-Those sysexts should work will all Fedora based image mode systems (Atomic
-Desktops, CoreOS, IoT, etc.), wether they are Bootable Containers (bootc)
-images, or classic ostree/rpm-ostree systems. They should also work with
-derivative images such as Bluefin, Aurora or Bazzite from the Universal Blue
-project.
-
-Some sysexts are designed for specific variants only (i.e. for Fedora CoreOS
-only for example). This is generally detailed on each sysext's page. Make
-sure to verify for each sysext for which variant it was made. Feel free to
-submit issues or pull-requests if you think there is an error.
+See [extensions.fcos.fr/compatibility](https://extensions.fcos.fr/compatibility).
 
 ## Building, contributing and licenses
 

--- a/libvirtd/justfile
+++ b/libvirtd/justfile
@@ -48,6 +48,7 @@ quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 quay.io/fedora/fedora-coreos:next x86_64,aarch64
 "
 # Pending nfs-utils packaging rework
+# Fixed in Fedora 44
 pre_commands := "dnf remove -y nfs-utils-coreos"
 
 import '../sysext.just'


### PR DESCRIPTION
docs: Move compatibility note to the shared docs

---

libvirtd: nfs-utils-coreos fixed in F44